### PR TITLE
Major cleanup of MultiWorld.sk

### DIFF
--- a/MultiWorld.sk
+++ b/MultiWorld.sk
@@ -1,5 +1,5 @@
 #   . MultiWorld (Skript), Developped by alexisl315 (Alias: Lennord).
-#   . This skript allows you to redo all or almost all the functionality of the MultiWorld and Multiverse-Core plugin.
+#   . This script allows you to redo all or almost all the functionality of the MultiWorld and Multiverse-Core plugin.
 
 #   --> Code:
 
@@ -9,66 +9,58 @@ on load:
 		set yaml value "language" from "config" to "English"
 		set yaml value "world.not-delete.world" from "config" to true
 		save yaml "config"
-		unload yaml "config"
-		stop
 	else:
 		load "plugins/MultiWorld/config.yml"
 		yaml value "language" from "config" != "English" or "Français":
 			set yaml value "language" from "config" to "English"
-		save yaml "config"
-		unload yaml "config"
-		stop
-
-on load:
+			save yaml "config"
+	set {multiworld::language} to yaml value "language" from "config"
 	send "&7[&bMultiWorld&7] &8x &2Enabled" to console
 
 on unload:
 	send "&7[&bMultiWorld&7] &8x &cDisabled" to console
 
 function MultiWorldNoPermission(s: sender):
-	load "plugins/MultiWorld/config.yml"
-	yaml value "language" from "config" = "English":
-		send "&4| &8x &cYou have not permission to use this command." to {_s}
-	yaml value "language" from "config" = "Français":
+	if {multiworld::language} = "English":
+		send "&4| &8x &cYou do not have permission to use this command." to {_s}
+	else if {multiworld::language} = "Français":
 		send "&4| &8x &cVous n'avez pas la permission d'utiliser cette commande." to {_s}
 
 function MultiWorldNoCommandConsole(s: sender):
-	load "plugins/MultiWorld/config.yml"
-	yaml value "language" from "config" = "English":
+	if {multiworld::language} = "English":
 		send "&4| &8x &cYou must be a player to use this command." to {_s}
-	yaml value "language" from "config" = "Français":
+	else if {multiworld::language} = "Français":
 		send "&4| &8x &cVous devez être un joueur pour pouvoir utiliser cette commande." to {_s}
 
 function MultiWorldHelp(s: sender, typehelp: text):
-	load "plugins/MultiWorld/config.yml"
-	yaml value "language" from "config" = "English":
+	if {multiworld::language} = "English":
 		send "" to {_s}
 		send "&8| &8x &6Help:" to {_s}
 		send "" to {_s}
 		{_typehelp} = "MultiworldCMD":
-			send "&8| &f/multiworld &binfo &8x &7Seen informations of this skript." to {_s}
-			send "&8| &f/multiworld &breload &8x &7Reload this skript." to {_s}
+			send "&8| &f/multiworld &binfo &8x &7See information of this script." to {_s}
+			send "&8| &f/multiworld &breload &8x &7Reload this script." to {_s}
 			send "" to {_s}
 		{_typehelp} = "WorldCMD":
-			send "&8| &f/world &bcreate &f[&cname of new world&f] &f[&cworld type&f] &8x &7Create new world type." to {_s}
-			send "&8| &f/world &bdelete &f[&cname of world&f] &8x &7Delete world type." to {_s}
-			send "&8| &f/world &btp&f/&bteleport &f[&cname of world&f] &8x &7Teleport to world type." to {_s}
-			send "&8| &f/world &bload &f[&cname of world&f] &8x &7Load world type." to {_s}
-			send "&8| &f/world &bunload &f[&cname of world&f] &8x &7Unload world type." to {_s}
-			send "&8| &f/world &bdifficulty &f[&cname of world&f] &f[&cpeaceful&7, &ceasy&7, &cnormal&7, &chard&f] &8x &7Modify the difficulty of world type." to {_s}
-			send "&8| &f/world &btime &f[&cname of world&f] &f[&cday&7, &cnight&f] &8x &7Modify the times of world type." to {_s}
-			send "&8| &f/world &binfo &f[&cname of world&f] &8x &7Info of world type." to {_s}
-			send "&8| &f/world &bsetspawn &8x &7Modify the spawn of world type." to {_s}
-			send "&8| &f/world &blist &8x &7List of all worlds types." to {_s}
-			send "&8| &f/world &bhelp &8x &7Seen all commands of the skript." to {_s}
+			send "&8| &f/world &bcreate &f[&cname of new world&f] &f[&cworld environment&f] &f[&cworld type&f] &8x &7Create new world." to {_s}
+			send "&8| &f/world &bdelete &f[&cname of world&f] &8x &7Delete world." to {_s}
+			send "&8| &f/world &btp&f/&bteleport &f[&cname of world&f] &8x &7Teleport to world." to {_s}
+			send "&8| &f/world &bload &f[&cname of world&f] &8x &7Load world." to {_s}
+			send "&8| &f/world &bunload &f[&cname of world&f] &8x &7Unload world." to {_s}
+			send "&8| &f/world &bdifficulty &f[&cname of world&f] &f[&cpeaceful&7, &ceasy&7, &cnormal&7, &chard&f] &8x &7Modify the difficulty of world." to {_s}
+			send "&8| &f/world &btime &f[&cname of world&f] &f[&cday&7, &cnight&f] &8x &7Modify the time of world." to {_s}
+			send "&8| &f/world &binfo &f[&cname of world&f] &8x &7Info of world." to {_s}
+			send "&8| &f/world &bsetspawn &8x &7Modify the spawn of world." to {_s}
+			send "&8| &f/world &blist &8x &7List of all worlds." to {_s}
+			send "&8| &f/world &bhelp &8x &7Seen all commands of the script." to {_s}
 			send "" to {_s}
-	yaml value "language" from "config" = "Français":
+	else if {multiworld::language} = "Français":
 		send "" to {_s}
 		send "&8| &8x &6Aide:" to {_s}
 		send "" to {_s}
 		{_typehelp} = "MultiworldCMD":
 			send "&8| &f/multiworld &binfo &8x &7Voir les informations sur le skript." to {_s}
-			send "&8| &f/multiworld &breload &8x &7Redémarrer le skript." to {_s}
+			send "&8| &f/multiworld &breload &8x &7Redémarrer le script." to {_s}
 			send "" to {_s}
 		{_typehelp} = "WorldCMD":
 			send "&8| &f/world &bcreate &f[&cnom du mondeorld&f] &f[&ctype de monde&f] &8x &7Créer un type de monde." to {_s}
@@ -84,228 +76,174 @@ function MultiWorldHelp(s: sender, typehelp: text):
 			send "&8| &f/world &bhelp &8x &7Voir toutes les commandes du skript." to {_s}
 			send "" to {_s}
 
+on tab complete of "multiworld":
+	set tab completions for position 1 to "info" and "reload"
+
 command /multiworld [<text>] [<text>]:
 	aliases: /mw, multiworld:multiworld, multiworld:mw
 	description: &fMultiworld command /multiworld.
 	trigger:
-		arg 1 isn't set:
+		if sender doesn't have permission "multiworld.multiworld":
+			MultiWorldNoPermission(player)
+		else if arg-1 isn't set:
 			MultiWorldHelp(sender, "MultiworldCMD")
-		else:
-			arg 1 != "info" or "reload":
-				MultiWorldHelp(sender, "MultiworldCMD")
-			arg 1 = "info":
-				load "plugins/MultiWorld/config.yml"
-				yaml value "language" from "config" = "English":
+		else:	
+			if arg 1 = "info":
+				if {multiworld::language} = "English":
 					send "" to sender
 					send "&8| &8x &6Help:" to sender
 					send "" to sender
-					send "&8| &fName of skript: &cMultiWorld (Skript)" to sender
-					send "&8| &fAuthor of skript: &calexisl315 (Alias: Lennord)" to sender
-					send "&8| &fDescription of skript: &cThis skript allows you to redo all or almost all the functionality of the MultiWorld and Multiverse-Core plugin." to sender
-					send "&8| &fVersion of skript: &c2.0.4" to sender
+					send "&8| &fName of script: &cMultiWorld (Skript)" to sender
+					send "&8| &fAuthor of script: &calexisl315 (Alias: Lennord)" to sender
+					send "&8| &fDescription of script: &cThis script allows you to redo all or almost all the functionality of the MultiWorld and Multiverse-Core plugin." to sender
+					send "&8| &fVersion of script: &c2.0.4" to sender
 					send "&8| &fPlugins requirements: &cSkript&7, &cSkript-YAML &7and &cSkBee" to sender
 					send "&8| &fAll languages of skript: &cEnglish &7and &cFrançais" to sender
 					send "" to sender
-				yaml value "language" from "config" = "Français":
+				else if {multiworld::language} = "Français":
 					send "" to sender
 					send "&8| &8x &6Aide:" to sender
 					send "" to sender
-					send "&8| &fNom du skript: &cMultiWorld (Skript)" to sender
-					send "&8| &fAuteur du skript: &calexisl315 (Aliase: Lennord)" to sender
-					send "&8| &fDescription du skript: &cCe skript permet de refaire toutes ou presque toutes les fonctionnalités du plugin MultiWorld et Multiverse-Core." to sender
-					send "&8| &fVersion du skript: &c2.0.4" to sender
+					send "&8| &fNom du script: &cMultiWorld (Skript)" to sender
+					send "&8| &fAuteur du script: &calexisl315 (Aliase: Lennord)" to sender
+					send "&8| &fDescription du script: &cCe script permet de refaire toutes ou presque toutes les fonctionnalités du plugin MultiWorld et Multiverse-Core." to sender
+					send "&8| &fVersion du script: &c2.0.4" to sender
 					send "&8| &fPlugins obligatoires: &cSkript&7, &cSkript-YAML &7et &cSkBee" to sender
 					send "&8| &fTous les langues du skript: &cEnglish &7et &cFrançais" to sender
 					send "" to sender
-			arg 1 = "reload":
-				make console execute command "/sk reload MultiWorld"
-				load "plugins/MultiWorld/config.yml"
-				yaml value "language" from "config" = "English":
-					send "&7You have been reloaded the skript." to sender
-				yaml value "language" from "config" = "Français":
-					send "&7Vous avez redémarré le skript." to sender
+			else if arg 1 = "reload":
+				reload script script
+				if {multiworld::language} = "English":
+					send "&7You have been reloaded the script." to sender
+				else if {multiworld::language} = "Français":
+					send "&7Vous avez redémarré le script." to sender
+			else:
+				MultiWorldHelp(sender, "MultiworldCMD")
 
-on command "/multiworld" or "/multiworld:multiworld":
-	sender = player:
-		player doesn't have permission "multiworld.multiworld" or "multiworld.*":
-			cancel event
-			MultiWorldNoPermission(player)
+on tab complete of "world":
+	set tab completions for position 1 to "create", "delete", "teleport", "tp", "list", "load", "unload", "info", "difficulty", "time" and "setspawn"
+	if tab arg-1 = "create":
+		set tab completions for position 2 to "<name>"
+		set tab completions for position 3 to "normal", "nether", "the_end"
+		set tab completions for position 4 to "amplified", "flat", "large_biomes", "normal"
+	else if tab arg-1 = "delete", "unload", "info", "difficulty", "time", "spawnpoint", "tp" or "teleport":
+		set tab completions for position 2 to all worlds
+		if tab arg-1 = "difficulty":
+			set tab completions for position 3 to "peaceful", "easy", "normal" and "hard"
+		else if tab arg-1 = "time":
+			set tab completions for position 3 to "dusk", "day", "dawn" and "night"
+	else if tab arg-1 = "load":
+		set tab completions for position 2 to "<name>"
+
 
 command /world [<text>] [<text>] [<text>] [<text>]:
 	aliases: multiworld:world
 	description: &fMultiworld command /world.
 	trigger:
-		sender = player:
-			load "plugins/MultiWorld/config.yml"
-			arg 1 isn't set:
+		sender = a player:
+			player doesn't have permission "multiworld.world":
+				MultiWorldNoPermission(player)
+			else if arg 1 isn't set:
 				MultiWorldHelp(player, "WorldCMD")
 			else:
 				arg 1 != "create" or "delete" or "teleport" or "tp" or "list" or "load" or "unload" or "info" or "difficulty" or "time" or "setspawn":
 					MultiWorldHelp(player, "WorldCMD")
 				arg 1 = "create":
-					player has permission "multiworld.*" or "multiworld.world.create" or "multiworld.world.*":
+					player has permission "multiworld.world.create":
 						arg 2 isn't set:
 							MultiWorldHelp(player, "WorldCMD")
 						else:
-							(arg 2 parsed as world) is set:
-								yaml value "language" from "config" = "English":
-									send "&4| &8x &cThe world &6%arg 2% &cis already exist." to player
-								yaml value "language" from "config" = "Français":
+							world(arg-2) is set:
+								if {multiworld::language} = "English":
+									send "&4| &8x &cThe world &6%arg 2% &calready exist." to player
+								else if {multiworld::language} = "Français":
 									send "&4| &8x &cLe monde &6%arg 2% &cn'existe pas." to player
 							else:
 								arg 3 isn't set:
 									MultiWorldHelp(player, "WorldCMD")
 								else:
-									arg 3 != "normal" or "nether" or "end" or "largebiome" or "amplified" or "flat":
-										yaml value "language" from "config" = "English":
-											send "&6List of all worlds types: &cNormal &8x &cNether &8x &cEnd &8x &cLargeBiome &8x &cAmplified &8x &cFlat" to player
-										yaml value "language" from "config" = "Français":
-											send "&6List de tous les types de mondes: &cNormal &8x &cNether &8x &cEnd &8x &cLargeBiome &8x &cAmplified &8x &cFlat" to player
-									arg 3 = "normal":
-										set {_MultiWorld::%player's uuid%::worldcreator} to new world creator named arg 2
-										load world from creator {_MultiWorld::%player's uuid%::worldcreator}
-										yaml value "language" from "config" = "English":
-											send "&7You have created new world &6%arg 2%&7. &7(&cNormal&7)" to player
-										yaml value "language" from "config" = "Français":
-											send "&7Vous avez créer le monde &6%arg 2%&7. &7(&cNormal&7)" to player
-									arg 3 = "nether":
-										set {_MultiWorld::%player's uuid%::worldcreator} to new world creator named arg 2
-										set environment of {_MultiWorld::%player's uuid%::worldcreator} to nether
-										load world from creator {_MultiWorld::%player's uuid%::worldcreator}
-										yaml value "language" from "config" = "English":
-											send "&7You have created new world &6%arg 2%&7. &7(&cNether&7)" to player
-										yaml value "language" from "config" = "Français":
-											send "&7Vous avez créer le monde &6%arg 2%&7. &7(&cNether&7)" to player
-									arg 3 = "end":
-										set {_MultiWorld::%player's uuid%::worldcreator} to new world creator named arg 2
-										set environment of {_MultiWorld::%player's uuid%::worldcreator} to the end
-										load world from creator {_MultiWorld::%player's uuid%::worldcreator}
-										yaml value "language" from "config" = "English":
-											send "&7You have created new world &6%arg 2%&7. &7(&cThe End&7)" to player
-										yaml value "language" from "config" = "Français":
-											send "&7Vous avez créer le monde &6%arg 2%&7. &7(&cThe End&7)" to player
-									arg 3 = "largebiome":
-										arg 4 != "normal" or "nether" or "end":
-											yaml value "language" from "config" = "English":
-												send "&6List of all worlds types of LargeBiomes: &cNormal &8x &cNether &8x &cEnd" to player
-											yaml value "language" from "config" = "Français":
-												send "&6Liste des types de mondes de LargeBiomes: &cNormal &8x &cNether &8x &cEnd" to player
-										arg 4 = "normal":
-											set {_MultiWorld::%player's uuid%::worldcreator} to new world creator named arg 2
-											set world type of {_MultiWorld::%player's uuid%::worldcreator} to large biomes
-											load world from creator {_MultiWorld::%player's uuid%::worldcreator}
-											yaml value "language" from "config" = "English":
-												send "&7You have created new world &6%arg 2%&7. &7(&cNormal &8x &cLargeBiomes&7)" to player
-											yaml value "language" from "config" = "Français":
-												send "&7Vous avez créer le monde &6%arg 2%&7. &7(&cNormal &8x &cLargeBiomes&7)" to player
-										arg 4 = "nether":
-											set {_MultiWorld::%player's uuid%::worldcreator} to new world creator named arg 2
-											set environment of {_MultiWorld::%player's uuid%::worldcreator} to nether
-											set world type of {_MultiWorld::%player's uuid%::worldcreator} to large biomes
-											load world from creator {_MultiWorld::%player's uuid%::worldcreator}
-											yaml value "language" from "config" = "English":
-												send "&7You have created new world &6%arg 2%&7. &7(&cNether &8x &cLargeBiomes&7)" to player
-											yaml value "language" from "config" = "Français":
-												send "&7Vous avez créer le monde &6%arg 2%&7. &7(&cNether &8x &cLargeBiomes&7)" to player
-										arg 4 = "end":
-											set {_MultiWorld::%player's uuid%::worldcreator} to new world creator named arg 2
-											set environment of {_MultiWorld::%player's uuid%::worldcreator} to the end
-											set world type of {_MultiWorld::%player's uuid%::worldcreator} to large biomes
-											load world from creator {_MultiWorld::%player's uuid%::worldcreator}
-											yaml value "language" from "config" = "English":
-												send "&7You have created new world &6%arg 2%&7. &7(&cNormal &8x &cLargeBiomes&7)" to player
-											yaml value "language" from "config" = "Français":
-												send "&7Vous avez créer le monde &6%arg 2%&7. &7(&cThe End &8x &cLargeBiomes&7)" to player
-									arg 3 = "amplified":
-										arg 4 != "normal" or "nether" or "end":
-											yaml value "language" from "config" = "English":
-												send "&6List of all worlds types of Amplified: &cNormal &8x &cNether &8x &cEnd" to player
-											yaml value "language" from "config" = "Français":
-												send "&6Liste des types de mondes de Amplified: &cNormal &8x &cNether &8x &cEnd" to player
-										arg 4 = "normal":
-											set {_MultiWorld::%player's uuid%::worldcreator} to new world creator named arg 2
-											set world type of {_MultiWorld::%player's uuid%::worldcreator} to amplified
-											load world from creator {_MultiWorld::%player's uuid%::worldcreator}
-											yaml value "language" from "config" = "English":
-												send "&7You have created new world &6%arg 2%&7. &7(&cNormal &8x &cAmplified&7)" to player
-											yaml value "language" from "config" = "Français":
-												send "&7Vous avez créer le monde &6%arg 2%&7. &7(&cNormal &8x &cAmplified&7)" to player
-										arg 4 = "nether":
-											set {_MultiWorld::%player's uuid%::worldcreator} to new world creator named arg 2
-											set environment of {_MultiWorld::%player's uuid%::worldcreator} to nether
-											set world type of {_MultiWorld::%player's uuid%::worldcreator} to amplified
-											load world from creator {_MultiWorld::%player's uuid%::worldcreator}
-											yaml value "language" from "config" = "English":
-												send "&7You have created new world &6%arg 2%&7. &7(&cNether &8x &cAmplified&7)" to player
-											yaml value "language" from "config" = "Français":
-												send "&7Vous avez créer le monde &6%arg 2%&7. &7(&cNether &8x &cAmplified&7)" to player
-										arg 4 = "end":
-											set {_MultiWorld::%player's uuid%::worldcreator} to new world creator named arg 2
-											set environment of {_MultiWorld::%player's uuid%::worldcreator} to the end
-											set world type of {_MultiWorld::%player's uuid%::worldcreator} to amplified
-											load world from creator {_MultiWorld::%player's uuid%::worldcreator}
-											yaml value "language" from "config" = "English":
-												send "&7You have created new world &6%arg 2%&7. &7(&cNormal &8x &cAmplified&7)" to player
-											yaml value "language" from "config" = "Français":
-												send "&7Vous avez créer le monde &6%arg 2%&7. &7(&cThe End &8x &cAmplified&7)" to player
-									arg 3 = "flat":
-										set {_MultiWorld::%player's uuid%::worldcreator} to new world creator named arg 2
-										set world type of {_MultiWorld::%player's uuid%::worldcreator} to flat
-										load world from creator {_MultiWorld::%player's uuid%::worldcreator}
-										yaml value "language" from "config" = "English":
-											send "&7You have created new world &6%arg 2%&7. &7(&cNormal&7)" to player
-										yaml value "language" from "config" = "Français":
-											send "&7Vous avez créer le monde &6%arg 2%&7. &7(&cNormal&7)" to player
+									set {_env} to arg-3 parsed as environment
+									set {_type} to arg-4 parsed as world type
+									if {_env} is not set:
+										if {multiworld::language} = "English":
+											send "&6List of all worlds environments: &cNormal &8x &cNether &8x &cEnd" to player
+										else if {multiworld::language} = "Français":
+											send "&6List de tous les environnements de mondes: &cNormal &8x &cNether &8x &cEnd" to player
+									else if {_type} is not set:
+										if {multiworld::language} = "English":
+											send "&6List of all worlds types: &cNormal &8x &cLarge_Biomes &8x &cAmplified &8x &cFlat" to player
+										else if {multiworld::language} = "Français":
+											send "&6List de tous les types de mondes: &cNormal &8x &cLarge_Biomes &8x &cAmplified &8x &cFlat" to player
+									else:
+										set {_creator} to new world creator named arg-2
+										set environment of {_creator} to {_env}
+										set world type of {_creator} to {_type}
+										load world from creator {_creator}
+
+										set {_e} to "%{_env}%"
+										set {_t} to "%{_type}%"
+										replace "_" with " " in {_e}
+										replace "_" with " " in {_t}
+
+										if {multiworld::language} = "English":
+											send "&7You have created new world &6%arg 2%&7. &7(&c%strict proper case {_e}% &8x &c%strict proper case {_t}%&7)" to player
+										else if {multiworld::language} = "Français":
+											send "&7Vous avez créer le monde &6%arg 2%&7. &7(&c%strict proper case {_e}% &8x &c%strict proper case {_t}%&7)" to player
 					else:
 						MultiWorldNoPermission(player)
 				arg 1 = "delete":
-					player has permission "multiworld.world.delete" or "multiworld.world.*" or "multiworld.*":
+					player has permission "multiworld.world.delete":
 						arg 2 isn't set:
 							MultiWorldHelp(player, "WorldCMD")
 						else:
-							(arg 2 parsed as world) isn't set:
-								yaml value "language" from "config" = "English":
-									send "&4| &8x &cThe world &6%arg 2% &cis not exist." to player
-								yaml value "language" from "config" = "Français":
+							set {_world} to world(arg-2)
+							if {_world} isn't set:
+								if {multiworld::language} = "English":
+									send "&4| &8x &cThe world &6%arg 2% &cdoes not exist." to player
+								else if {multiworld::language} = "Français":
 									send "&4| &8x &cLe monde &6%arg 2% &cn'existe pas." to player
 							else:
-								yaml value "world.not-delete.%arg 2 parsed as world%" from "config" = true:
-									yaml value "language" from "config" = "English":
-										send "&4| &8x &cThe world &6%arg 2% &cis not deleted because this world is world default." to player
-									yaml value "language" from "config" = "Français":
+								if {_world} = first element of all worlds:
+									if {multiworld::language} = "English":
+										send "&4| &8x &cThe world &6%arg 2% &ccan not deleted because it is the default world." to player
+									else if {multiworld::language} = "Français":
 										send "&4| &8x &cLe monde &6%arg 2% &cne peut pas être supprimer, car, ce monde est un monde normal." to player
 								else:
-									yaml value "language" from "config" = "English":
-										send "&7You have deleted the world &6%arg 2 parsed as world%&7." to player
-									yaml value "language" from "config" = "Français":
-										send "&7Vous avez supprimé le monde &6%arg 2 parsed as world%&7." to player
-									delete world file for "%arg 2 parsed as world%"
+									unload world {_world}
+									delete world file for arg-2
+									if {multiworld::language} = "English":
+										send "&7You have deleted the world &6%arg 2%&7." to player
+									else if {multiworld::language} = "Français":
+										send "&7Vous avez supprimé le monde &6%arg 2%&7." to player
 					else:
 						MultiWorldNoPermission(player)
 				arg 1 = "teleport" or "tp":
-					player has permission "multiworld.world.teleport.%arg 2%" or "multiworld.world.teleport.*" or "multiworld.world.*" or "multiworld.*":
+					player has permission "multiworld.world.teleport.%arg 2%":
 						arg 2 isn't set:
 							MultiWorldHelp(player, "WorldCMD")
 						else:
-							(arg 2 parsed as world) isn't set:
-								yaml value "language" from "config" = "English":
-									send "&4| &8x &cThe world &6%arg 2% &cis not exist." to player
-								yaml value "language" from "config" = "Français":
+							set {_world} to world(arg-2)
+							if {_world} isn't set:
+								if {multiworld::language} = "English":
+									send "&4| &8x &cThe world &6%arg 2% &cdoes not exist." to player
+								else if {multiworld::language} = "Français":
 									send "&4| &8x &cLe monde &6%arg 2% &cn'existe pas." to player
 							else:
-								teleport player to spawn of arg 2 parsed as world
-								yaml value "language" from "config" = "English":
-									send "&7You have been teleported in the world &6%arg 2 parsed as world%&7." to player
-								yaml value "language" from "config" = "Français":
-									send "&7Vous avez été téléporté dans le monde &6%arg 2 parsed as world%&7." to player
+								teleport player to spawn of {_world}
+								if {multiworld::language} = "English":
+									send "&7You have been teleported to the world &6%arg 2%&7." to player
+								else if {multiworld::language} = "Français":
+									send "&7Vous avez été téléporté dans le monde &6%arg 2%&7." to player
 					else:
 						MultiWorldNoPermission(player)
 				arg 1 = "list":
-					player has permission "multiworld.world.list" or "multiworld.world.*" or  "multiworld.*":
-						yaml value "language" from "config" = "English":
-							send "&6List of all worlds&7: &c%all worlds%" to player
-						yaml value "language" from "config" = "Français":
-							send "&6Liste de tous les mondes&7: &c%all worlds%" to player
+					player has permission "multiworld.world.list":
+						set {_worlds} to "%all worlds%"
+						replace "," and " and" with "&7,&c" in {_worlds}
+						if {multiworld::language} = "English":
+							send "&6List of all worlds&7: &c%{_worlds}%" to player
+						else if {multiworld::language} = "Français":
+							send "&6Liste de tous les mondes&7: &c%{_worlds}%" to player
 					else:
 						MultiWorldNoPermission(player)
 				arg 1 = "load":
@@ -313,17 +251,17 @@ command /world [<text>] [<text>] [<text>] [<text>]:
 						arg 2 isn't set:
 							MultiWorldHelp(player, "WorldCMD")
 						else:
-							(arg 2 parsed as world) is set:
-								yaml value "language" from "config" = "English":
-									send "&4| &8x &cThe world &6%arg 2% &cis already exist." to player
-								yaml value "language" from "config" = "Français":
+							world(arg-2) is set:
+								if {multiworld::language} = "English":
+									send "&4| &8x &cThe world &6%arg 2% &calready exist." to player
+								else if {multiworld::language} = "Français":
 									send "&4| &8x &cLe monde &6%arg 2% &cexiste déjà." to player
 							else:
-								load world arg 2
-								yaml value "language" from "config" = "English":
-									send "&7You have loaded the world &6%arg 2 parsed as world%&7." to player
-								yaml value "language" from "config" = "Français":
-									send "&7Vous avez chargé le monde &6%arg 2 parsed as world%&7." to player
+								load world arg-2
+								if {multiworld::language} = "English":
+									send "&7You have loaded the world &6%arg 2%&7." to player
+								else if {multiworld::language} = "Français":
+									send "&7Vous avez chargé le monde &6%arg 2%&7." to player
 					else:
 						MultiWorldNoPermission(player)
 				arg 1 = "unload":
@@ -331,136 +269,119 @@ command /world [<text>] [<text>] [<text>] [<text>]:
 						arg 2 isn't set:
 							MultiWorldHelp(player, "WorldCMD")
 						else:
-							(arg 2 parsed as world) is set:
-								yaml value "language" from "config" = "English":
-									send "&4| &8x &cThe world &6%arg 2% &cis already exist." to player
-								yaml value "language" from "config" = "Français":
-									send "&4| &8x &cLe monde &6%arg 2% &cexiste déjà." to player
+							set {_world} to world(arg-2)
+							if {_world} is not set:
+								if {multiworld::language} = "English":
+									send "&4| &8x &cThe world &6%arg 2% &cdoes not exist." to player
+								else if {multiworld::language} = "Français":
+									send "&4| &8x &cLe monde &6%arg 2% &cexiste déjà." to player #you will need to update your french here
+							else if {_world} = first element of all worlds:
+								if {multiworld::language} = "English":
+									send "&4| &8x &cThe world &6%arg 2% &ccannot be unloaded as it is the default world." to player
+								else if {multiworld::language} = "Français":
+									send "&4| &8x &cLe monde &6%arg 2% &cexiste déjà." to player #you will need to update your french here
 							else:
-								unload world arg 2 parsed as world
-								yaml value "language" from "config" = "English":
-									send "&7You have unloaded the world &6%arg 2 parsed as world%&7." to player
-								yaml value "language" from "config" = "Français":
-									send "&7Vous avez déchargé le monde &6%arg 2 parsed as world%&7." to player
+								unload world(arg-2)
+								if {multiworld::language} = "English":
+									send "&7You have unloaded the world &6%arg 2%&7." to player
+								else if {multiworld::language} = "Français":
+									send "&7Vous avez déchargé le monde &6%arg 2%&7." to player
 					else:
 						MultiWorldNoPermission(player)
 				arg 1 = "info":
-					player has permission "multiworld.world.info.%arg 2%" or "multiworld.world.info.*" or "multiworld.world.*" or "multiworld.*":
+					player has permission "multiworld.world.info.%arg 2%":
 						arg 2 isn't set:
 							MultiWorldHelp(player, "WorldCMD")
 						else:
-							(arg 2 parsed as world) isn't set:
-								yaml value "language" from "config" = "English":
-									send "&4| &8x &cThe world &6%arg 2% &cis not exist." to player
-								yaml value "language" from "config" = "Français":
+							set {_world} to world(arg-2)
+							if {_world} isn't set:
+								if {multiworld::language} = "English":
+									send "&4| &8x &cThe world &6%arg 2% &cdoes not exist." to player
+								else if {multiworld::language} = "Français":
 									send "&4| &8x &cLe monde &6%arg 2% &cexiste déjà." to player
 							else:
-								yaml value "language" from "config" = "English":
+								if {multiworld::language} = "English":
 									send "" to sender
 									send "&8| &8x &6Help:" to sender
 									send "" to sender
-									send "&8| &fName of world: &c%arg 2 parsed as world%" to sender
-									send "&8| &fSeed of world: &c%seed of arg 2 parsed as world%" to sender
-									send "&8| &fDifficulty of world&6: &c%difficulty of arg 2 parsed as world%" to sender
-									send "&8| &fTime of world&6: &c%time of arg 2 parsed as world%" to sender
+									send "&8| &fName of world: &c%{_world}%" to sender
+									send "&8| &fSeed of world: &c%seed of {_world}%" to sender
+									send "&8| &fDifficulty of world&6: &c%difficulty of {_world}%" to sender
+									send "&8| &fTime of world&6: &c%time of {_world}%" to sender
 									send "" to sender
-								yaml value "language" from "config" = "Français":
+								else if {multiworld::language} = "Français":
 									send "" to sender
 									send "&8| &8x &6Aide:" to sender
 									send "" to sender
-									send "&8| &fNom du monde: &c%arg 2 parsed as world%" to sender
-									send "&8| &fGraine du monde: &c%seed of arg 2 parsed as world%" to sender
-									send "&8| &fDifficulté du monde&6: &c%difficulty of arg 2 parsed as world%" to sender
-									send "&8| &fTemps du monde&6: &c%time of arg 2 parsed as world%" to sender
+									send "&8| &fNom du monde: &c%{_world}%" to sender
+									send "&8| &fGraine du monde: &c%seed of {_world}%" to sender
+									send "&8| &fDifficulté du monde&6: &c%difficulty of {_world}%" to sender
+									send "&8| &fTemps du monde&6: &c%time of {_world}%" to sender
 									send "" to sender
 					else:
 						MultiWorldNoPermission(player)
 				arg 1 = "difficulty":
-					player has permission "multiworld.world.difficulty.%arg 2%" or "multiworld.world.difficulty.*" or "multiworld.world.*" or "multiworld.*":
+					player has permission "multiworld.world.difficulty.%arg 2%":
 						arg 2 isn't set:
 							MultiWorldHelp(player, "WorldCMD")
 						else:
-							(arg 2 parsed as world) isn't set:
-								yaml value "language" from "config" = "English":
-									send "&4| &8x &cThe world &6%arg 2% &cis not exist." to player
-								yaml value "language" from "config" = "Français":
+							set {_world} to world(arg-2)
+							if {_world} isn't set:
+								if {multiworld::language} = "English":
+									send "&4| &8x &cThe world &6%arg 2% &cdoes not exist." to player
+								else if {multiworld::language} = "Français":
 									send "&4| &8x &cLe monde &6%arg 2% &cn'existe pas." to player
 							else:
 								arg 3 isn't set:
 									MultiWorldHelp(player, "WorldCMD")
 								else:
-									arg 3 != "peaceful" or "easy" or "normal" or "hard":
+									set {_diff} to arg-3 parsed as difficulty
+									if {_diff} is not set:
 										send "&6List of all difficulty types: &cPeaceful &8x &cEasy &8x &cNormal &8x &cHard" to player
-									arg 3 = "peaceful":
-										set difficulty of arg 2 parsed as world to peaceful
-										yaml value "language" from "config" = "English":
-											send "&7You have modified the difficulty of the world &6%arg 2 parsed as world%&7. &7(&cPeaceful&7)" to player
-										yaml value "language" from "config" = "Français":
-											send "&7Vous avez modifié la diffilculté du monde &6%arg 2 parsed as world%&7. &7(&cPeaceful&7)" to player
-									arg 3 = "easy":
-										set difficulty of arg 2 parsed as world to easy
-										yaml value "language" from "config" = "English":
-											send "&7You have modified the difficulty of the world &6%arg 2 parsed as world%&7. &7(&cEasy&7)" to player
-										yaml value "language" from "config" = "Français":
-											send "&7Vous avez modifié la diffilculté du monde &6%arg 2 parsed as world%&7. &7(&cEasy&7)" to player
-									arg 3 = "normal":
-										set difficulty of arg 2 parsed as world to medium
-										yaml value "language" from "config" = "English":
-											send "&7You have modified the difficulty of the world &6%arg 2 parsed as world%&7. &7(&cNormal&7)" to player
-										yaml value "language" from "config" = "Français":
-											send "&7Vous avez modifié la diffilculté du monde &6%arg 2 parsed as world%&7. &7(&cNormal&7)" to player
-									arg 3 = "hard":
-										set difficulty of arg 2 parsed as world to hard
-										yaml value "language" from "config" = "English":
-											send "&7You have modified the difficulty of the world &6%arg 2 parsed as world%&7. &7(&cHard&7)" to player
-										yaml value "language" from "config" = "Français":
-											send "&7Vous avez modifié la diffilculté du monde &6%arg 2 parsed as world%&7. &7(&cHard&7)" to player
+									else:
+										set difficulty of {_world} to {_diff}
+										set {_d} to strict proper case "%{_diff}%"
+										if {_d} = "Medium":
+											set {_d} to "Normal" #Silly Skript using "Medium"
+										if {multiworld::language} = "English":
+											send "&7You have modified the difficulty of the world &6%arg 2 parsed as world%&7. &7(&c%{_d}%&7)" to player
+										else if {multiworld::language} = "Français":
+											send "&7Vous avez modifié la diffilculté du monde &6%arg 2 parsed as world%&7. &7(&c%{_d}%7)" to player
 					else:
 						MultiWorldNoPermission(player)
 				arg 1 = "time":
-					player has permission "multiworld.world.time.%arg 2%" or "multiworld.world.time.*" or "multiworld.world.*" or "multiworld.*":
+					player has permission "multiworld.world.time.%arg 2%":
 						arg 2 isn't set:
 							MultiWorldHelp(player, "WorldCMD")
 						else:
-							(arg 2 parsed as world) isn't set:
-								yaml value "language" from "config" = "English":
+							set {_world} to world(arg-2)
+							if {_world} isn't set:
+								if {multiworld::language} = "English":
 									send "&4| &8x &cThe world &6%arg 2% &cis not exist." to player
-								yaml value "language" from "config" = "Français":
+								else if {multiworld::language} = "Français":
 									send "&4| &8x &cLe monde &6%arg 2% &cn'existe pas." to player
 							else:
 								arg 3 isn't set:
 									MultiWorldHelp(player, "WorldCMD")
 								else:
-									arg 3 != "day" or "night":
+									set {_time} to arg-3 parsed as time period
+									if {_time} is not set:
 										MultiWorldHelp(player, "WorldCMD")
-									arg 3 = "day":
-										set time of arg 2 parsed as world to 6:00
-										yaml value "language" from "config" = "English":
-											send "&7You have modified time in the world &6%arg 2 parsed as world%&7." to player
-										yaml value "language" from "config" = "Français":
-											send "&7Vous avez modifié le temps du monde &6%arg 2 parsed as world%&7." to player
-									arg 3 = "night":
-										set time of arg 2 parsed as world to 19:30
-										yaml value "language" from "config" = "English":
-											send "&7You have modified time in the world &6%arg 2 parsed as world%&7." to player
-										yaml value "language" from "config" = "Français":
-											send "&7Vous avez modifié le temps du monde &6%arg 2 parsed as world%&7." to player
+									set time of {_world} to {_time}
+									if {multiworld::language} = "English":
+										send "&7You have modified time in the world &6%arg 2%&7." to player
+									else if {multiworld::language} = "Français":
+										send "&7Vous avez modifié le temps du monde &6%arg 2%&7." to player
 					else:
 						MultiWorldNoPermission(player)
 				arg 1 = "setspawn":
-					player has permission "multiworld.world.setspawn" or "multiworld.world.*" or "multiworld.*":
+					player has permission "multiworld.world.setspawn":
 						set spawn point of player's world to player's location
-						yaml value "language" from "config" = "English":
+						if {multiworld::language} = "English":
 							send "&7You have modified the spawn location of the world &6%player's world%&7." to player
-						yaml value "language" from "config" = "Français":
+						else if {multiworld::language} = "Français":
 							send "&7Vous avez modifié le point de spawn du monde &6%player's world%&7." to player
 					else:
 						MultiWorldNoPermission(player)
 		sender = console:
 			MultiWorldNoCommandConsole(console)
-
-on command "/world" or "/multiworld:world":
-	sender = player:
-		player doesn't have permission "multiworld.world" or "multiworld.*":
-			cancel event
-			MultiWorldNoPermission(player)


### PR DESCRIPTION
This PR aims to do a **MAJOR** cleanup of this script. 

## Changes:
- Clean up English (fix some grammar issues)
- Remove need to constantly load the yaml file (this can lag your server) (on load:  save the language into a var)
- Clean up the permissions for commands (these can/should be done within the command, not an `on command` event)
- General cleanup of code (a lot of repeat code)
- Change "Skript" to "script" in most cases (Skript's files are called "scripts" not "Skripts")
- Added a tab completer for the commands (makes handling the commands much easier)
- Time command now supports dawn, day, dusk and night